### PR TITLE
chore: git submodules 사용해서 민감 설정 파일 관리하도록 설정

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "server/src/main/resources/security"]
+	path = server/src/main/resources/security
+	url = https://github.com/Sunflower-yonsei/sunflower-server-submodules.git

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -1,11 +1,4 @@
 spring:
-  datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:sunflower
-    username: sa
-    password:
-  jpa:
-    open-in-view: false
-    database-platform: org.hibernate.dialect.H2Dialect
-    hibernate:
-      ddl-auto: create
+  config:
+  import:
+    - security/application.yml

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -1,4 +1,4 @@
 spring:
   config:
-  import:
-    - security/application.yml
+    import:
+      - security/application.yml


### PR DESCRIPTION
## 주요 변경사항

- secret key, db 접속 비밀번호 등을 Public 레포지토리 통해 관리할 수 없어서 서버를 띄울 때 private 레포 통해서 정보를 가져오는 방식입니다.
- git submodules 관련한 내용은 [이 포스팅](https://engineerinsight.tistory.com/272) 참고해주세용
- 이후에 배포하거나 할 때는 깃허브 토큰을 통해서 서브모듈 private 레포지토리에 접근 권한을 줘야 합니당

## 관련 이슈

closes #11 