### PR TITLE
feat: original file name을 반환하도록 수정

### DIFF
--- a/server/src/main/java/sunflower/server/api/TranslationApiController.java
+++ b/server/src/main/java/sunflower/server/api/TranslationApiController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import sunflower.server.api.response.BrfFileQueryResponse;
+import sunflower.server.api.response.PdfRegisterResponse;
 import sunflower.server.api.response.TranslationStatusResponse;
 import sunflower.server.application.TranslationService;
 import sunflower.server.application.dto.TranslationStatusDto;
@@ -43,7 +44,7 @@ public class TranslationApiController {
                     required = true
             ))
     @PostMapping(consumes = MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<Void> registerPdf(
+    public ResponseEntity<PdfRegisterResponse> registerPdf(
             @Parameter(name = "file", description = "점역할 pdf 파일", required = true,
                     example = "쎈_3124번.pdf", schema = @Schema(type = "file"))
             @RequestPart("file") MultipartFile file
@@ -56,7 +57,7 @@ public class TranslationApiController {
 
         return ResponseEntity
                 .created(URI.create("/translations/" + id))
-                .build();
+                .body(PdfRegisterResponse.from(file.getOriginalFilename()));
     }
 
     @Operation(summary = "점역 상황 체크 API", description = "id와 함께 요청하면 점역 진행 상황을 반환하며, 클라이언트의 progress bar 표시를 위해 사용해 주세요.")

--- a/server/src/main/java/sunflower/server/api/response/PdfRegisterResponse.java
+++ b/server/src/main/java/sunflower/server/api/response/PdfRegisterResponse.java
@@ -1,0 +1,20 @@
+package sunflower.server.api.response;
+
+import lombok.Getter;
+
+@Getter
+public class PdfRegisterResponse {
+
+    private String originalFileName;
+
+    public PdfRegisterResponse() {
+    }
+
+    public PdfRegisterResponse(final String originalFileName) {
+        this.originalFileName = originalFileName;
+    }
+
+    public static PdfRegisterResponse from(final String originalFilename) {
+        return new PdfRegisterResponse(originalFilename);
+    }
+}


### PR DESCRIPTION
## 주요 변경사항

- @JunhyeongPark-kr 의 수정 제안으로 pdf 업로드 후에 업로드한 파일 이름을 body로 함께 반환하도록 수정했습니다

<img width="1041" alt="image" src="https://github.com/Sunflower-yonsei/sunflower-server/assets/107979804/cd78f474-ff89-4e97-acf4-d5c4428565cf">

## 관련 이슈

closes #76

#### ✔️ Squash & Merge 방식으로 병합해 주세요!
